### PR TITLE
fix: nodrag option.

### DIFF
--- a/dragscroll.js
+++ b/dragscroll.js
@@ -42,11 +42,20 @@
                 (cont = el.container || el)[addEventListener](
                     mousedown,
                     cont.md = function(e) {
-                        // Return if the element or it's parent cannot be dragged.
+                        // Return if the target (of the mousedown event) or any of it's ancestors cannot be dragged.
                         // Ideally composedPath() would be used here but it's not supported by IE.
                         // https://stackoverflow.com/a/39245638
-                        if (e.target.hasAttribute('nodrag') || e.target.parentNode.hasAttribute('nodrag')) {
+                        var element = e.target;
+                        var elements = [];
+                        while (element) {
+                            elements.push(element);
+                            element = element.parentNode;
+                        }
+                        console.log(elements)
+                        for (j = 0; j < elements.length; j++) {
+                          if (typeof elements[j].hasAttribute === 'function' && elements[j].hasAttribute('nodrag')) {
                             return true;
+                          }
                         }
 
                         if (!el.hasAttribute('nochilddrag') || _document.elementFromPoint(e.pageX, e.pageY) == cont) {

--- a/dragscroll.js
+++ b/dragscroll.js
@@ -51,7 +51,6 @@
                             elements.push(element);
                             element = element.parentNode;
                         }
-                        console.log(elements)
                         for (j = 0; j < elements.length; j++) {
                           if (typeof elements[j].hasAttribute === 'function' && elements[j].hasAttribute('nodrag')) {
                             return true;


### PR DESCRIPTION
The X-browser solution in 6eb6313 only checked the parent on the target
element which is not sufficient when the areas click becomes complex.
The nodrag option should imply that any child element should not be able
to be dragged.